### PR TITLE
Update to R code to expect temp directory as input

### DIFF
--- a/R/set_element.R
+++ b/R/set_element.R
@@ -16,6 +16,7 @@ if (length(argst) > 1) {
   pid = as.integer(sqldf(q,
     connection = ds$connection)$featureid[1]
   )
+  tempDirectory <- argst[3]
 }
 #message(paste("Found pid: ", pid, "for elementid", elid))
 #message(paste("Calling ds$get_json_prop(",pid,")") )
@@ -35,7 +36,7 @@ for (i in names(element_list)) {
 
 element_json <- jsonlite::prettify(jsonlite::toJSON(element_list, auto_unbox = TRUE))
 #element_json <- paste0('"',stringr::str_replace_all(jsonlite::toJSON(element_list),'"','\"'),'"')
-element_path <- paste0("element_", elid,".json")
+element_path <- paste0(tempDirectory,"/element_", elid,".json")
 write(element_json,element_path)
 if (!is.na(elid)) {
   cmd_str <- paste("php import_element_json.php", elid, element_path )


### PR DESCRIPTION
Added the temp directory to the R Script `set_element.R`. This script is called in the meta model in `om->manage->migrate` and nowhere else (or at least, nowhere else in the meta model):
```
grep -R "set_element.R" ./*
./models/om/manage/migrate/01_dh_to_om:Rscript /opt/model/om/R/set_element.R pid $segment $tempdir
```

I introduced this change because I was having trouble writing out the JSON file on this same line, constantly getting permissions errors related to trying to write it out. Now it will write out directly to the temp directory which is certainly writable. 

A corresponding change will be needed in the meta model. See https://github.com/HARPgroup/meta_model/pull/155